### PR TITLE
Update OSS drivers to a config-free setup

### DIFF
--- a/pci/graphic_drivers/catalyst/MHWDCONFIG
+++ b/pci/graphic_drivers/catalyst/MHWDCONFIG
@@ -22,6 +22,7 @@ DEPENDS_64="lib32-catalyst-utils"
 DEPKMOD="catalyst"
 
 XORGFILE="/etc/X11/mhwd.d/catalyst.conf"
+ALT_XORGFILE="/etc/X11/xorg.conf"
 
 post_install()
 {
@@ -36,6 +37,10 @@ post_remove()
 {
 	if [ -e "${XORGFILE}" ]; then
 		rm "${XORGFILE}"
+	fi
+
+        if [ -f "${ALT_XORGFILE}" ]; then
+		rm "${ALT_XORGFILE}"
 	fi
 
 	mhwd-gpu --check

--- a/pci/graphic_drivers/hybrid-intel-amdgpu-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-amdgpu-prime/MHWDCONFIG
@@ -2,9 +2,9 @@
 
 NAME="video-hybrid-intel-amdgpu-prime"
 INFO="Solution for hybrid Intel + AMD systems."
-VERSION="2017.03.12"
+VERSION="2017.05.29"
 FREEDRIVER="true"
-PRIORITY="6"
+PRIORITY="7"
 
 # Intel cards
 CLASSIDS="0300"

--- a/pci/graphic_drivers/hybrid-intel-amdgpu-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-amdgpu-prime/MHWDCONFIG
@@ -1,0 +1,38 @@
+# mhwd Driver Config
+
+NAME="video-hybrid-intel-amdgpu-prime"
+INFO="Solution for hybrid Intel + AMD systems."
+VERSION="2017.03.12"
+FREEDRIVER="true"
+PRIORITY="6"
+
+# Intel cards
+CLASSIDS="0300"
+VENDORIDS="8086"
+DEVICEIDS="*"
+BLACKLISTEDDEVICEIDS="0be1 8108"
+
+# AMD cards
+CLASSIDS="0300 0380"
+VENDORIDS="1002"
+DEVICEIDS=">/var/lib/mhwd/ids/pci/amdgpu.ids"
+
+
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-intel video-amdgpu video-hybrid-intel-ati-bumblebee"
+
+# Dependencies
+DEPENDS="xf86-video-amdgpu xf86-video-intel vulkan-intel vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-vulkan-intel lib32-vulkan-radeon lib32-libva-vdpau-driver lib32-mesa-vdpau"
+
+
+post_install()
+{
+    mhwd-gpu --check
+}
+
+post_remove()
+{
+    mhwd-gpu --check
+}
+

--- a/pci/graphic_drivers/hybrid-intel-ati-bumblebee/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-ati-bumblebee/MHWDCONFIG
@@ -9,7 +9,7 @@ PRIORITY="6"
 # AMD cards
 CLASSIDS="0300 0380"
 VENDORIDS="1002"
-DEVICEIDS="*"
+DEVICEIDS=">/var/lib/mhwd/ids/pci/ati.ids"
 
 # Intel cards
 CLASSIDS="0300"

--- a/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
@@ -19,7 +19,7 @@ DEVICEIDS="*"
 
 
 # Conflicts with other mhwd configs
-MHWDCONFLICTS="video-intel video-nouveau video-hybrid-intel-nvidia-bumblebee"
+MHWDCONFLICTS="video-intel video-nouveau video-nvidia video-nvidia-304xx video-nvidia-340xx video-hybrid-intel-nvidia-bumblebee video-hybrid-intel-nvidia-340xx-bumblebee"
 
 # Dependencies
 DEPENDS="xf86-video-intel xf86-video-nouveau vulkan-intel vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"

--- a/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
@@ -1,0 +1,38 @@
+# mhwd Driver Config
+
+NAME="video-hybrid-intel-nouveau-prime"
+INFO="Solution for hybrid Intel + Nvidia systems."
+VERSION="2017.03.12"
+FREEDRIVER="true"
+PRIORITY="6"
+
+# Intel cards
+CLASSIDS="0300"
+VENDORIDS="8086"
+DEVICEIDS="*"
+BLACKLISTEDDEVICEIDS="0be1 8108"
+
+# Nvidia Cards
+CLASSIDS="0300 0302"
+VENDORIDS="10de"
+DEVICEIDS="*"
+
+
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-intel video-nouveau video-hybrid-intel-nvidia-bumblebee"
+
+# Dependencies
+DEPENDS="xf86-video-intel xf86-video-nouveau vulkan-intel vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-vulkan-intel lib32-libva-vdpau-driver lib32-mesa-vdpau"
+
+
+post_install()
+{
+    mhwd-gpu --check
+}
+
+post_remove()
+{
+    mhwd-gpu --check
+}
+

--- a/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-hybrid-intel-nouveau-prime"
 INFO="Solution for hybrid Intel + Nvidia systems."
-VERSION="2017.03.12"
+VERSION="2017.05.29"
 FREEDRIVER="true"
 PRIORITY="6"
 

--- a/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-nouveau-prime/MHWDCONFIG
@@ -22,7 +22,7 @@ DEVICEIDS="*"
 MHWDCONFLICTS="video-intel video-nouveau video-nvidia video-nvidia-304xx video-nvidia-340xx video-hybrid-intel-nvidia-bumblebee video-hybrid-intel-nvidia-340xx-bumblebee"
 
 # Dependencies
-DEPENDS="xf86-video-intel xf86-video-nouveau vulkan-intel vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS="xf86-video-intel xf86-video-nouveau vulkan-intel libva-mesa-driver libva-vdpau-driver mesa-vdpau"
 DEPENDS_64="lib32-vulkan-intel lib32-libva-vdpau-driver lib32-mesa-vdpau"
 
 
@@ -35,4 +35,3 @@ post_remove()
 {
     mhwd-gpu --check
 }
-

--- a/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
@@ -1,0 +1,46 @@
+# mhwd Driver Config
+
+NAME="video-hybrid-intel-radeon-prime"
+INFO="Solution for hybrid Intel + AMD Radeon systems."
+VERSION="2017.03.12"
+FREEDRIVER="true"
+PRIORITY="6"
+
+# Intel cards
+CLASSIDS="0300"
+VENDORIDS="8086"
+DEVICEIDS="*"
+BLACKLISTEDDEVICEIDS="0be1 8108"
+
+# AMD Radeon cards
+CLASSIDS="0300 0380"
+VENDORIDS="1002"
+DEVICEIDS=">/var/lib/mhwd/ids/pci/ati.ids"
+
+
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-intel video-ati video-hybrid-intel-ati-bumblebee"
+
+# Dependencies
+DEPENDS="xf86-video-ati xf86-video-intel vulkan-intel libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-vulkan-intel lib32-libva-vdpau-driver lib32-mesa-vdpau"
+
+# Files
+MODULESFILE="/etc/modprobe.d/mhwd-radeon_nopm.conf"
+
+
+post_install()
+{
+    # Deactivate Radeon PowerManagement because of a bug in it
+    # Radeon will run in Full-Power mode all the time.
+    # This is not a big deal, since it will completely unloaded when not in use.
+    MHWD_HEADING "${MODULESFILE}"
+    echo "options radeon runpm=0" >> "${MODULESFILE}"
+
+    mhwd-gpu --check
+}
+
+post_remove()
+{
+    mhwd-gpu --check
+}

--- a/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
@@ -2,9 +2,9 @@
 
 NAME="video-hybrid-intel-radeon-prime"
 INFO="Solution for hybrid Intel + AMD Radeon systems."
-VERSION="2017.03.12"
+VERSION="2017.05.29"
 FREEDRIVER="true"
-PRIORITY="6"
+PRIORITY="7"
 
 # Intel cards
 CLASSIDS="0300"

--- a/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
@@ -19,7 +19,7 @@ DEVICEIDS=">/var/lib/mhwd/ids/pci/ati.ids"
 
 
 # Conflicts with other mhwd configs
-MHWDCONFLICTS="video-intel video-ati video-hybrid-intel-ati-bumblebee"
+MHWDCONFLICTS="video-intel video-ati video-catalyst video-hybrid-intel-ati-bumblebee"
 
 # Dependencies
 DEPENDS="xf86-video-ati xf86-video-intel vulkan-intel libva-mesa-driver libva-vdpau-driver mesa-vdpau"

--- a/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-intel-radeon-prime/MHWDCONFIG
@@ -40,6 +40,14 @@ post_install()
     mhwd-gpu --check
 }
 
+pre_remove()
+{
+    if [ -f "${MODULESFILE}" ]
+        then
+            rm "${MODULESFILE}"
+    fi
+}
+
 post_remove()
 {
     mhwd-gpu --check

--- a/pci/graphic_drivers/hybrid-radeon-amdgpu-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-radeon-amdgpu-prime/MHWDCONFIG
@@ -1,0 +1,36 @@
+# mhwd Driver Config
+
+NAME="video-hybrid-radeon-amdgpu-prime"
+INFO="Solution for hybrid AMD Radeon + AMD AMDGPU systems."
+VERSION="2017.03.12"
+FREEDRIVER="true"
+PRIORITY="6"
+
+# AMD Radeon cards
+CLASSIDS="0300 0380"
+VENDORIDS="1002"
+DEVICEIDS=">/var/lib/mhwd/ids/pci/ati.ids"
+
+# AMDGPU cards
+CLASSIDS="0300 0380"
+VENDORIDS="1002"
+DEVICEIDS=">/var/lib/mhwd/ids/pci/amdgpu.ids"
+
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-radeon video-amdgpu"
+
+# Dependencies
+DEPENDS="xf86-video-ati xf86-video-amdgpu vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-vulkan-radeon lib32-libva-vdpau-driver lib32-mesa-vdpau"
+
+
+post_install()
+{
+    mhwd-gpu --check
+}
+
+post_remove()
+{
+    mhwd-gpu --check
+}
+

--- a/pci/graphic_drivers/hybrid-radeon-amdgpu-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-radeon-amdgpu-prime/MHWDCONFIG
@@ -16,8 +16,9 @@ CLASSIDS="0300 0380"
 VENDORIDS="1002"
 DEVICEIDS=">/var/lib/mhwd/ids/pci/amdgpu.ids"
 
+
 # Conflicts with other mhwd configs
-MHWDCONFLICTS="video-radeon video-amdgpu"
+MHWDCONFLICTS="video-radeon video-amdgpu video-catalyst"
 
 # Dependencies
 DEPENDS="xf86-video-ati xf86-video-amdgpu vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"

--- a/pci/graphic_drivers/hybrid-radeon-amdgpu-prime/MHWDCONFIG
+++ b/pci/graphic_drivers/hybrid-radeon-amdgpu-prime/MHWDCONFIG
@@ -2,9 +2,9 @@
 
 NAME="video-hybrid-radeon-amdgpu-prime"
 INFO="Solution for hybrid AMD Radeon + AMD AMDGPU systems."
-VERSION="2017.03.12"
+VERSION="2017.05.29"
 FREEDRIVER="true"
-PRIORITY="6"
+PRIORITY="7"
 
 # AMD Radeon cards
 CLASSIDS="0300 0380"

--- a/pci/graphic_drivers/xf86-video-amdgpu/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-amdgpu/MHWDCONFIG
@@ -10,6 +10,10 @@ CLASSIDS="0300 0380"
 VENDORIDS="1002"
 DEVICEIDS=">/var/lib/mhwd/ids/pci/amdgpu.ids"
 
+
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-catalyst video-hybrid-intel-amdgpu-prime video-hybrid-radeon-amdgpu-prime"
+
 # Dependencies
 DEPENDS="xf86-video-amdgpu vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"
 DEPENDS_64="lib32-vulkan-radeon lib32-libva-vdpau-driver lib32-mesa-vdpau"

--- a/pci/graphic_drivers/xf86-video-amdgpu/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-amdgpu/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-amdgpu"
 INFO="X.org amdgpu video driver. Standard open source driver for AMD graphic cards."
-VERSION="2016.08.22"
+VERSION="2017.03.24"
 FREEDRIVER="true"
 PRIORITY="3"
 
@@ -11,50 +11,37 @@ VENDORIDS="1002"
 DEVICEIDS=">/var/lib/mhwd/ids/pci/amdgpu.ids"
 
 # Dependencies
-DEPENDS="xf86-video-amdgpu"
+DEPENDS="xf86-video-amdgpu vulkan-radeon libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-vulkan-radeon lib32-libva-vdpau-driver lib32-mesa-vdpau"
 
-XORGFILE="/etc/X11/mhwd.d/amdgpu.conf"
-MODULESFILE="/etc/modules-load.d/mhwd-amdgpu.conf"
-MODULESBLACKLIST="/etc/modprobe.d/mhwd-amdgpu.conf"
+
+pre_install()
+{
+    # Cleaning up old installation files.
+    ## Xorg
+    if [ -f "/etc/X11/mhwd.d/amdgpu.conf" ]
+        then
+            rm "/etc/X11/mhwd.d/amdgpu.conf"
+    fi
+
+    ## Modules
+    if [ -f "/etc/modules-load.d/mhwd-amdgpu.conf" ]
+        then
+            rm "/etc/modules-load.d/mhwd-amdgpu.conf"
+    fi
+
+    if [ -f "/etc/modprobe.d/mhwd-amdgpu.conf" ]
+        then
+            rm "/etc/modprobe.d/mhwd-amdgpu.conf"
+    fi
+}
 
 post_install()
 {
-	MHWD_HEADING "${XORGFILE}"
-	MHWD_ADD_DEVICE_SECTION_FOR_EACH_BUSID "amdgpu" "${XORGFILE}" 1002
-	MHWD_ADD_DRI "${XORGFILE}"
-	MHWD_ADD_COMPOSITING "${XORGFILE}"
-	MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-	# Enable next generation of DRI
-	sed -i "s/\tOption      \"DRI\"    \"true\"/\tOption      \"DRI3\"    \"1\"\n\tOption      \"DRI\"     \"3\"/g"  "${XORGFILE}"
-
-	MHWD_HEADING "${MODULESFILE}"
-	echo "amdgpu" >> "${MODULESFILE}"
-
-	MHWD_HEADING "${MODULESBLACKLIST}"
-	echo "blacklist radeon" >> "${MODULESBLACKLIST}"
-
-	# Unload modules if X is not running
-	if [ ! "$(pgrep X)" ];	then
-		rmmod -f radeon
-	fi
-
-	modprobe amdgpu
-
-	mhwd-gpu --setxorg "${XORGFILE}"
+    mhwd-gpu --check
 }
 
 post_remove()
 {
-	if [ -e "${XORGFILE}" ]; then
-		rm "${XORGFILE}"
-	fi
-	if [ -e "${MODULESFILE}" ]; then
-		rm "${MODULESFILE}"
-	fi
-	if [ -e "${MODULESBLACKLIST}" ]; then
-		rm "${MODULESBLACKLIST}"
-	fi
-
-	mhwd-gpu --check
+    mhwd-gpu --check
 }

--- a/pci/graphic_drivers/xf86-video-ati/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-ati/MHWDCONFIG
@@ -10,13 +10,14 @@ CLASSIDS="0300 0380"
 VENDORIDS="1002"
 DEVICEIDS=">/var/lib/mhwd/ids/pci/ati.ids"
 
+
 # Conflicts with other mhwd configs
-MHWDCONFLICTS="video-hybrid-intel-ati-bumblebee"
+MHWDCONFLICTS="video-catalyst  video-hybrid-intel-radeon-prime video-hybrid-radeon-amdgpu-prime video-hybrid-intel-ati-bumblebee"
 
 # Dependencies
-
 DEPENDS="xf86-video-ati libva-mesa-driver libva-vdpau-driver mesa-vdpau"
 DEPENDS_64="lib32-libva-vdpau-driver lib32-mesa-vdpau"
+
 
 pre_install()
 {

--- a/pci/graphic_drivers/xf86-video-ati/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-ati/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-ati"
 INFO="X.org ati video driver. Standard open source driver for AMD graphic cards."
-VERSION="2017.03.12"
+VERSION="2017.03.24"
 FREEDRIVER="true"
 PRIORITY="2"
 
@@ -10,30 +10,30 @@ CLASSIDS="0300 0380"
 VENDORIDS="1002"
 DEVICEIDS=">/var/lib/mhwd/ids/pci/ati.ids"
 
-# Dependencies
-DEPENDS="xf86-video-ati"
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-hybrid-intel-ati-bumblebee"
 
-XORGFILE="/etc/X11/mhwd.d/ati.conf"
+# Dependencies
+
+DEPENDS="xf86-video-ati libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-libva-vdpau-driver lib32-mesa-vdpau"
+
+pre_install()
+{
+    # Cleaning up old installation files.
+    ## Xorg
+    if [ -f "/etc/X11/mhwd.d/ati.conf" ]
+        then
+            rm "/etc/X11/mhwd.d/ati.conf"
+    fi
+}
 
 post_install()
 {
-	MHWD_HEADING "${XORGFILE}"
-	MHWD_ADD_DEVICE_SECTION_FOR_EACH_BUSID "radeon" "${XORGFILE}" 1002
-	MHWD_ADD_DRI "${XORGFILE}"
-	MHWD_ADD_COMPOSITING "${XORGFILE}"
-	MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-	# Enable next generation of DRI
-	sed -i "s/\tOption      \"DRI\"    \"true\"/\tOption      \"DRI3\"    \"1\"\n\tOption      \"DRI\"     \"3\"/g"  "${XORGFILE}"
-
-	mhwd-gpu --setxorg "${XORGFILE}"
+    mhwd-gpu --check
 }
 
 post_remove()
 {
-	if [ -e "${XORGFILE}" ]; then
-		rm "${XORGFILE}"
-	fi
-
-	mhwd-gpu --check
+    mhwd-gpu --check
 }

--- a/pci/graphic_drivers/xf86-video-intel/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-intel/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-intel"
 INFO="X.org intel video driver. Standard open source driver for intel graphic cards."
-VERSION="2017.03.12"
+VERSION="2017.03.24"
 FREEDRIVER="true"
 PRIORITY="2"
 
@@ -12,33 +12,29 @@ DEVICEIDS="*"
 BLACKLISTEDDEVICEIDS="0be1 8108"
 
 # Conflicts with other mhwd configs
-MHWDCONFLICTS="video-hybrid-intel-nvidia-bumblebee video-hybrid-intel-nouveau-bumblebee"
+MHWDCONFLICTS="video-hybrid-intel-nvidia-bumblebee"
 
 # Dependencies
-DEPENDS="xf86-video-intel"
+DEPENDS="xf86-video-intel vulkan-intel libva-mesa-driver"
+DEPENDS_64="lib32-vulkan-intel"
 
-XORGFILE="/etc/X11/mhwd.d/intel.conf"
+
+pre_install()
+{
+    # Cleaning up old installation files.
+    ## Xorg
+    if [ -f "/etc/X11/mhwd.d/intel.conf" ]
+        then
+            rm "/etc/X11/mhwd.d/intel.conf"
+    fi
+}
 
 post_install()
 {
-	# Create intel xorg configuration with enabled sna acceleration method
-	MHWD_HEADING "${XORGFILE}"
-	MHWD_ADD_DEVICE_SECTION_FOR_EACH_BUSID "intel" "${XORGFILE}" 8086 "Option      \"AccelMethod\" \"sna\""
-	MHWD_ADD_DRI "${XORGFILE}"
-	MHWD_ADD_COMPOSITING "${XORGFILE}"
-	MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-	# Enable next generation of DRI
-	sed -i "s/\tOption      \"DRI\"    \"true\"/\tOption      \"DRI3\"    \"1\"\n\tOption      \"DRI\"     \"3\"/g"  "${XORGFILE}"
-
-	mhwd-gpu --setxorg "${XORGFILE}"
+    mhwd-gpu --check
 }
 
 post_remove()
 {
-	if [ -e "${XORGFILE}" ]; then
-		rm "${XORGFILE}"
-	fi
-
-	mhwd-gpu --check
+    mhwd-gpu --check
 }

--- a/pci/graphic_drivers/xf86-video-intel/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-intel/MHWDCONFIG
@@ -11,8 +11,9 @@ VENDORIDS="8086"
 DEVICEIDS="*"
 BLACKLISTEDDEVICEIDS="0be1 8108"
 
+
 # Conflicts with other mhwd configs
-MHWDCONFLICTS="video-hybrid-intel-nvidia-bumblebee"
+MHWDCONFLICTS="video-hybrid-intel-amdgpu-prime video-hybrid-intel-radeon-prime video-hybrid-intel-nouveau-prime video-hybrid-intel-ati-bumblebee video-hybrid-intel-nouveau-bumblebee video-hybrid-intel-nvidia-340xx-bumblebee video-hybrid-intel-nvidia-bumblebee"
 
 # Dependencies
 DEPENDS="xf86-video-intel vulkan-intel libva-mesa-driver"

--- a/pci/graphic_drivers/xf86-video-nouveau/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-nouveau/MHWDCONFIG
@@ -10,6 +10,10 @@ CLASSIDS="0300 0302"
 VENDORIDS="10de"
 DEVICEIDS="*"
 
+
+# Conflicts with other mhwd configs
+MHWDCONFLICTS="video-hybrid-intel-nouveau-prime video-hybrid-intel-nouveau-bumblebee video-hybrid-intel-nvidia-340xx-bumblebee video-hybrid-intel-nvidia-bumblebee"
+
 # Dependencies
 DEPENDS="xf86-video-nouveau libva-mesa-driver libva-vdpau-driver mesa-vdpau"
 DEPENDS_64="lib32-libva-vdpau-driver lib32-mesa-vdpau"

--- a/pci/graphic_drivers/xf86-video-nouveau/MHWDCONFIG
+++ b/pci/graphic_drivers/xf86-video-nouveau/MHWDCONFIG
@@ -2,7 +2,7 @@
 
 NAME="video-nouveau"
 INFO="X.org nouveau video driver. Standard open source driver for nvidia graphic cards."
-VERSION="2017.03.12"
+VERSION="2017.03.24"
 FREEDRIVER="true"
 PRIORITY="2"
 
@@ -10,33 +10,27 @@ CLASSIDS="0300 0302"
 VENDORIDS="10de"
 DEVICEIDS="*"
 
-# Conflicts with other mhwd configs
-MHWDCONFLICTS="video-hybrid-intel-nouveau-bumblebee"
-
 # Dependencies
-DEPENDS="xf86-video-nouveau"
+DEPENDS="xf86-video-nouveau libva-mesa-driver libva-vdpau-driver mesa-vdpau"
+DEPENDS_64="lib32-libva-vdpau-driver lib32-mesa-vdpau"
 
-XORGFILE="/etc/X11/mhwd.d/nouveau.conf"
+
+pre_install()
+{
+    # Cleaning up old installation files.
+    ## Xorg
+    if [ -f "/etc/X11/mhwd.d/nouveau.conf" ]
+        then
+            rm "/etc/X11/mhwd.d/nouveau.conf"
+    fi
+}
 
 post_install()
 {
-	MHWD_HEADING "${XORGFILE}"
-	MHWD_ADD_DEVICE_SECTION_FOR_EACH_BUSID "nouveau" "${XORGFILE}" 10de
-	MHWD_ADD_DRI "${XORGFILE}"
-	MHWD_ADD_COMPOSITING "${XORGFILE}"
-	MHWD_ADD_BACKSPACE "${XORGFILE}"
-
-	# Enable next generation of DRI
-	sed -i /'Section "Device"'/,/'EndSection'/s/'EndSection'/"\tOption \"DRI\" \"3\"\nEndSection"/g "${XORGFILE}"
-
-	mhwd-gpu --setxorg "${XORGFILE}"
+    mhwd-gpu --check
 }
 
 post_remove()
 {
-	if [ -e "${XORGFILE}" ]; then
-		rm "${XORGFILE}"
-	fi
-
-	mhwd-gpu --check
+    mhwd-gpu --check
 }


### PR DESCRIPTION
For the OSS-graphicsdrivers (intel,radeon,amdgpu,noveau) I suggest to switch to a config-free setup. Xorg (and wayland) is able to detect the drivers by themself. It is also more flexible in case of new hardware, because no hardcoded PCI slots or anything like this.

For hybrid systems we should phase out bumblebee where we're able to (I dont know how the situation is with Nvidia blob).

Mesa Prime should work much better without configuration files. It will use the graphicschip, that is either set as main in BIOS/UEFI or attached to the main screen, as main graphics chip by default. Now the user can switch to the dedicated graphicscard with DRI_PRIME=1 <app>. GNOME seems to have this already integrated in the DE itself.