### PR TITLE
unblock radeon on video-catalyst un-installation

### DIFF
--- a/pci/graphic_drivers/catalyst/MHWDCONFIG
+++ b/pci/graphic_drivers/catalyst/MHWDCONFIG
@@ -23,6 +23,8 @@ DEPKMOD="catalyst"
 
 XORGFILE="/etc/X11/mhwd.d/catalyst.conf"
 ALT_XORGFILE="/etc/X11/xorg.conf"
+MHWDGPU_BLCKLSTRADEON="/etc/modprobe.d/mhwd-gpu.conf"
+MHWDGPU_FRCFGLRX="/etc/modules-load.d/mhwd-gpu.conf"
 
 post_install()
 {
@@ -41,6 +43,14 @@ post_remove()
 
         if [ -f "${ALT_XORGFILE}" ]; then
 		rm "${ALT_XORGFILE}"
+	fi
+
+        if [ -f "${MHWDGPU_BLCKLSTRADEON}" ]; then
+		sed -i '/^blacklist radeon/d' "${MHWDGPU_BLCKLSTRADEON}"
+	fi
+
+        if [ -f "${MHWDGPU_FRCFGLRX}" ]; then
+		sed -i '/^fglrx/d' "${MHWDGPU_FRCFGLRX}"
 	fi
 
 	mhwd-gpu --check


### PR DESCRIPTION
In the installation routine, with the call of 

mhwd-gpu --setmod catalyst

mhwd will create a blocking part for radeon, and a force loading of fglrx in `/etc/modprobe.d/mhwd-gpu.conf` & `/etc/modules-load.d/mhwd-gpu.conf`

Both parts will not removed, when uninstalling video-catalyst. Users of a radeon-supported graphicscard are now unable to to switch to video-ati or video-*-radeon-prime.

With this little change both blocking parts will removed and users should be able to load up radeon after system-restart just fine.

An [example in our forums](https://forum.manjaro.org/t/cannot-boot-into-desktop-after-changing-to-video-ati-driver/25668/13)
^ unlike here, i dont remove the files completely, but only the lines with `blacklist radeon`, `fglrx` so it should be save to use.
