### PR TITLE
Unblock nouveau on nvidia uninstallation

### DIFF
--- a/pci/graphic_drivers/nvidia-304xx/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-304xx/MHWDCONFIG
@@ -24,6 +24,8 @@ DEPENDS_64="lib32-nvidia-304xx-utils"
 DEPKMOD="nvidia-304xx"
 
 XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
+MHWDGPU_BLCKLSTNVIDIA="/etc/modprobe.d/mhwd-gpu.conf"
+MHWDGPU_MODLDNVIDIA="/etc/modules-load.d/mhwd-gpu.conf"
 
 fix_screen_flickering()
 {
@@ -48,6 +50,17 @@ post_remove()
 {
 	if [ -e "${XORGFILE}" ]; then
 		rm "${XORGFILE}"
+	fi
+
+	if [ -f "${MHWDGPU_BLCKLSTNVIDIA}" ]; then
+		sed -i '/^blacklist nouveau/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist ttm/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist drm_kms_helper/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist drm/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+	fi
+
+	if [ -f "${MHWDGPU_MODLDNVIDIA}" ]; then
+		sed -i '/^nvidia/d' "${MHWDGPU_MODLDNVIDIA}"
 	fi
 
 	mhwd-gpu --check

--- a/pci/graphic_drivers/nvidia-340xx/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia-340xx/MHWDCONFIG
@@ -24,6 +24,8 @@ DEPENDS_64="lib32-nvidia-340xx-utils"
 DEPKMOD="nvidia-340xx"
 
 XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
+MHWDGPU_BLCKLSTNVIDIA="/etc/modprobe.d/mhwd-gpu.conf"
+MHWDGPU_MODLDNVIDIA="/etc/modules-load.d/mhwd-gpu.conf"
 
 fix_screen_flickering()
 {
@@ -48,6 +50,17 @@ post_remove()
 {
 	if [ -e "${XORGFILE}" ]; then
 		rm "${XORGFILE}"
+	fi
+
+	if [ -f "${MHWDGPU_BLCKLSTNVIDIA}" ]; then
+		sed -i '/^blacklist nouveau/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist ttm/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist drm_kms_helper/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist drm/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+	fi
+
+	if [ -f "${MHWDGPU_MODLDNVIDIA}" ]; then
+		sed -i '/^nvidia/d' "${MHWDGPU_MODLDNVIDIA}"
 	fi
 
 	mhwd-gpu --check

--- a/pci/graphic_drivers/nvidia/MHWDCONFIG
+++ b/pci/graphic_drivers/nvidia/MHWDCONFIG
@@ -23,10 +23,9 @@ DEPENDS="nvidia-utils"
 DEPENDS_64="lib32-nvidia-utils"
 DEPKMOD="nvidia"
 
-
 XORGFILE="/etc/X11/mhwd.d/nvidia.conf"
-
-
+MHWDGPU_BLCKLSTNVIDIA="/etc/modprobe.d/mhwd-gpu.conf"
+MHWDGPU_MODLDNVIDIA="/etc/modules-load.d/mhwd-gpu.conf"
 
 fix_screen_flickering()
 {
@@ -62,6 +61,17 @@ post_remove()
 {
 	if [ -e "${XORGFILE}" ]; then
 		rm "${XORGFILE}"
+	fi
+
+	if [ -f "${MHWDGPU_BLCKLSTNVIDIA}" ]; then
+		sed -i '/^blacklist nouveau/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist ttm/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist drm_kms_helper/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+		sed -i '/^blacklist drm/d' "${MHWDGPU_BLCKLSTNVIDIA}"
+	fi
+
+	if [ -f "${MHWDGPU_MODLDNVIDIA}" ]; then
+		sed -i '/^nvidia/d' "${MHWDGPU_MODLDNVIDIA}"
 	fi
 
 	mhwd-gpu --check


### PR DESCRIPTION
Similar to the catalyst issue, which was fixed with PR https://github.com/manjaro/mhwd-db/pull/9.

This fixes issue https://github.com/manjaro/mhwd/issues/40, where nouveau remains blacklisted after nvidia is removed, causing a non functional display server for all users that change from proprietary back to the open driver.